### PR TITLE
scan-all extended by frequency

### DIFF
--- a/examples/wifi_scan_all.c
+++ b/examples/wifi_scan_all.c
@@ -75,7 +75,14 @@ int main(int argc, char **argv)
 			perror("Unable to get scan data");
 		else //wifi_scan_all returns the number of found stations, it may be greater than BSS_INFOS that's why we test for both in the loop
 			for(i=0;i<status && i<BSS_INFOS;++i)	
-				printf("%s %s signal %d dBm seen %d ms ago status %s\n",bssid_to_string(bss[i].bssid, mac), bss[i].ssid,  bss[i].signal_mbm/100, bss[i].seen_ms_ago, (bss[i].status==BSS_ASSOCIATED ? "associated" : ""));
+				printf("%s %s signal %d dBm on frequency %d MHz seen %d ms ago status %s\n",
+				   bssid_to_string(bss[i].bssid, mac), 
+				   bss[i].ssid,  
+				   bss[i].signal_mbm/100, 
+				   bss[i].frequency,
+				   bss[i].seen_ms_ago, 
+				   (bss[i].status==BSS_ASSOCIATED ? "associated" : "")
+				);
 
 		printf("\n");
 

--- a/wifi_scan.c
+++ b/wifi_scan.c
@@ -233,7 +233,8 @@ const struct attribute_validation NL80211_BSS_VALIDATION[]={
  {NL80211_BSS_INFORMATION_ELEMENTS, MNL_TYPE_BINARY},
  {NL80211_BSS_STATUS, MNL_TYPE_U32},
  {NL80211_BSS_SIGNAL_MBM, MNL_TYPE_U32},
- {NL80211_BSS_SEEN_MS_AGO, MNL_TYPE_U32} };
+ {NL80211_BSS_SEEN_MS_AGO, MNL_TYPE_U32},
+ {NL80211_BSS_FREQUENCY, MNL_TYPE_U32} };
 
 const struct attribute_validation NL80211_NEW_SCAN_RESULTS_VALIDATION[]={
  {NL80211_ATTR_IFINDEX, MNL_TYPE_U32},
@@ -661,6 +662,9 @@ void parse_NL80211_ATTR_BSS(struct nlattr *nested, struct netlink_channel *chann
 
 	if ( tb[NL80211_BSS_SEEN_MS_AGO])
 		bss->seen_ms_ago = mnl_attr_get_u32(tb[NL80211_BSS_SEEN_MS_AGO]);
+
+	if ( tb[NL80211_BSS_FREQUENCY])
+		bss->frequency = mnl_attr_get_u32(tb[NL80211_BSS_FREQUENCY]);
 
 	bss->status=status;
 

--- a/wifi_scan.h
+++ b/wifi_scan.h
@@ -33,6 +33,7 @@ struct bss_info
 	enum bss_status status;  //anything >=0 means that your are connected to this station/network
 	int32_t signal_mbm;  //signal strength in mBm, divide it by 100 to get signal in dBm
 	int32_t seen_ms_ago; //when the above information was collected
+	uint32_t frequency; // frequency on which AP is sending in mHz
 };
 
 // like above


### PR DESCRIPTION
Hi,

I added the frequency of the access point to bss_info for scanning mode. I needed this for my [Project](https://github.com/fzirker/wlan_pioneer).
Eventually this is also interesting for you. If not decline pull request. 

regards Florian